### PR TITLE
fix(controller): update requires to match filenames

### DIFF
--- a/app/scripts/process/controller.js
+++ b/app/scripts/process/controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var GetCss = require('../process/getcss');
-var MediaQuerieRotine = require('../process/mediaquerierotine');
-var TakePrintScreen = require('../process/takeprintscreen');
-var ReadHtml = require('../process/readHtml');
+var MediaQuerieRotine = require('../process/mediaquerieRotine');
+var TakePrintScreen = require('../process/takeprintScreen');
+var ReadHtml = require('../process/readhtml');
 var CustomSize = require('../process/customsize');
 
 var Q = require('q');


### PR DESCRIPTION
I was getting the following error when running the application locally and notice some of the requires capitalisation didn't match that of the actual files:

``` shell
[18265:1118/230151:ERROR:nw_shell.cc(336)] Error: Cannot find module '../process/mediaquerierotine'
    at Function.Module._resolveFilename (module.js:327:15)
    at Function.Module._load (module.js:264:25)
    at Module.require (module.js:356:17)
    at require (module.js:375:17)
    at Object.<anonymous> (/home/javier/projects/break-shot/app/scripts/process/controller.js:4:25)
    at Module._compile (module.js:451:26)
    at Object.Module._extensions..js (module.js:469:10)
    at Module.load (module.js:346:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:356:17)
[18265:1118/230151:INFO:CONSOLE(329)] "Uncaught Error: Cannot find module '../process/mediaquerierotine'", source: module.js (329)
```
